### PR TITLE
Add Rate Limit Protection for API Calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,7 +62,6 @@ func (c *Client) SetRateLimitProtection(rlp RateLimitProtection) {
 }
 
 func (c *Client) doRequest(method, url string, body io.Reader) ([]byte, error) {
-	fmt.Println("Making amara request " + url)
 	if c.rateLimitProtection.triggered {
 		return nil, fmt.Errorf("Amara API is currently being rate limited. try again later")
 	}
@@ -119,8 +118,6 @@ func (r *RateLimitProtection) start(res *http.Response) error {
 	} else {
 		wait = time.Duration(math.Pow(2, float64(r.counter))) * r.MinRetryDuration
 	}
-
-	fmt.Printf("Wait time: %s\n\n", wait)
 
 	if wait < r.MinRetryDuration {
 		wait = r.MinRetryDuration

--- a/client.go
+++ b/client.go
@@ -4,16 +4,28 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/sethgrid/pester"
 )
 
 type Client struct {
-	apiKey   string
-	team     string
-	endpoint string
+	apiKey              string
+	team                string
+	endpoint            string
+	rateLimitProtection RateLimitProtection
 	*pester.Client
+}
+
+type RateLimitProtection struct {
+	enabled          bool
+	triggered        bool
+	counter          uint
+	MinRetryDuration time.Duration
+	MaxRetryDuration time.Duration
 }
 
 func NewClient(apiKey, team string) *Client {
@@ -26,11 +38,35 @@ func NewClient(apiKey, team string) *Client {
 		apiKey,
 		team,
 		"https://amara.org/api",
+		RateLimitProtection{
+			MinRetryDuration: 5 * time.Second,
+			MaxRetryDuration: 20 * time.Minute,
+		},
 		httpClient,
 	}
 }
 
+func (c *Client) EnableRateLimitProtection() {
+	c.rateLimitProtection.enabled = true
+	c.rateLimitProtection.triggered = false
+	c.rateLimitProtection.counter = 0
+}
+
+func (c *Client) DisableRateLimitProtection() {
+	c.rateLimitProtection.enabled = false
+	c.rateLimitProtection.triggered = false
+}
+
+func (c *Client) SetRateLimitProtection(rlp RateLimitProtection) {
+	c.rateLimitProtection = rlp
+}
+
 func (c *Client) doRequest(method, url string, body io.Reader) ([]byte, error) {
+	fmt.Println("Making amara request " + url)
+	if c.rateLimitProtection.triggered {
+		return nil, fmt.Errorf("Amara API is currently being rate limited. try again later")
+	}
+
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
@@ -49,9 +85,61 @@ func (c *Client) doRequest(method, url string, body io.Reader) ([]byte, error) {
 		return nil, err
 	}
 	if res.StatusCode >= 400 {
+		if res.StatusCode == http.StatusTooManyRequests && c.rateLimitProtection.enabled {
+			if err := c.rateLimitProtection.start(res); err != nil {
+				return nil, err
+			}
+		}
+
 		// TODO: parse the data
 		return nil, fmt.Errorf("status %d: %s", res.StatusCode, data)
 	}
 
+	c.rateLimitProtection.reset()
+
 	return data, nil
+}
+
+func (r *RateLimitProtection) start(res *http.Response) error {
+	var wait time.Duration
+
+	retryAfterStr := res.Header.Get("Retry-After")
+	if retryAfterStr != "" {
+		retryAfter, err := strconv.Atoi(retryAfterStr)
+		if err == nil {
+			wait = time.Duration(retryAfter) * time.Second
+		} else {
+			retryAt, err := time.Parse(time.RFC1123, retryAfterStr)
+
+			wait = time.Until(retryAt)
+			if err != nil || wait < 0 {
+				return fmt.Errorf("Invalid Retry-After header: %s", retryAfterStr)
+			}
+		}
+	} else {
+		wait = time.Duration(math.Pow(2, float64(r.counter))) * r.MinRetryDuration
+	}
+
+	fmt.Printf("Wait time: %s\n\n", wait)
+
+	if wait < r.MinRetryDuration {
+		wait = r.MinRetryDuration
+	}
+
+	if wait > r.MaxRetryDuration {
+		wait = r.MaxRetryDuration
+	}
+
+	r.triggered = true
+	r.counter += 1
+	time.AfterFunc(wait, func() {
+		r.triggered = false
+	})
+
+	return nil
+}
+
+func (r *RateLimitProtection) reset() {
+	r.triggered = false
+	r.counter = 0
 }


### PR DESCRIPTION
The Amara API will rate limit an API key based off of usage. This adds an optional circuit breaker, that when enabled, will stop making API calls to the Amara backend, until some time has passed. This respects `Retry-After` headers so if the Amara API indicates a time to retry the request we will reset the circuit breaker at that time.
