### PR TITLE
update link to the api docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Build Status](https://travis-ci.org/nytimes/amara.svg?branch=master)](https://travis-ci.org/nytimes/amara)
 
-Go client for the [Amara API](https://amara.readthedocs.io/en/latest/api.html).
+Go client for the [Amara API](https://apidocs.amara.org).


### PR DESCRIPTION
The current link to the API documentation in the README returns a `404`.
Looks like [https://apidocs.amara.org](https://apidocs.amara.org) is the new site.

Cheers
Felix